### PR TITLE
Import xcp-python-libs-3.0.11-1

### DIFF
--- a/SOURCES/xcp-python-libs-3.0.10.tar.gz
+++ b/SOURCES/xcp-python-libs-3.0.10.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ee451b5bf97c6a6e26d6091f69e70769dcdf4a6f7b8558faeeaec57af185e34a
-size 133913

--- a/SOURCES/xcp-python-libs-3.0.11.tar.gz
+++ b/SOURCES/xcp-python-libs-3.0.11.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93b810a3d0859907b9a04b1347b94f3104aa959347d4a3697a77709e7701323a
+size 135118

--- a/SPECS/xcp-python-libs.spec
+++ b/SPECS/xcp-python-libs.spec
@@ -1,14 +1,15 @@
-%global package_speccommit 6c1f27d802c1e16edbea1e516ae7ffb36e179dd9
-%global usver 3.0.10
+%global package_speccommit 905c68dc2384a221c539896c21d9b228922238d1
+%global usver 3.0.11
 %global xsver 1
 %global xsrel %{xsver}%{?xscount}%{?xshash}
+%global package_srccommit v3.0.11
 %bcond_with test
 
 Summary: Common XenServer Python classes
 Name: xcp-python-libs
-Version: 3.0.10
+Version: 3.0.11
 Release: %{?xsrel}%{?dist}
-Source0: xcp-python-libs-3.0.10.tar.gz
+Source0: xcp-python-libs-3.0.11.tar.gz
 Patch0: 0001-Remove-setuptools_scm.patch
 %define __python python3
 License: GPL
@@ -75,6 +76,12 @@ cd tests
 %{python3_sitelib}/xcp
 
 %changelog
+* Fri Mar 20 2026 Stephen Cheng <stephen.cheng@citrix.com> - 3.0.11-1
+- CA-375347: Add API to get crash kernel memory by version
+- CP-53030: bootloader: add RPU chainloader
+- Fix pylint errors
+- CP-53030: bootloader: stop MenuEntry.contents getting clobbered by setNextBoot
+
 * Tue Sep 30 2025 Stephen Cheng <stephen.cheng@citrix.com> - 3.0.10-1
 - CA-417888: Fix a drucat bug
 - docs/ci: various update


### PR DESCRIPTION
### Main information

#### Work Item Reference

XCPNG-3278

#### Related changes (optional)

<!--When several PRs are part of a single changeset, you can either fill
the form for each PR, or just once and link towards the PR with the filled
form. In the reference PR, the one with the form filled in, list all related
PRs.

You can also mention here constraints between PRs, if useful:
merge/build order, chained builds...-->

- https://github.com/xcp-ng-rpms/varstored/pull/14
- https://github.com/xcp-ng-rpms/host-upgrade-plugin/pulls#XCPNG-3289

#### Context & Motivation

Sync with XenServer

Import xcp-python-libs-3.0.11-1

I don't know more than what is in changelog:

  - CA-375347: Add API to get crash kernel memory by version
  - CP-53030: bootloader: add RPU chainloader
  - Fix pylint errors
  - CP-53030: bootloader: stop MenuEntry.contents getting clobbered by setNextBoot
  
  
<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->


#### Release Target

- [ ] We already defined a release target with the release team.
- [x] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

8.3-next to align https://github.com/xcp-ng-rpms/varstored/pull/14


<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->



---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

Sync with XenServer




#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->



#### Documentation update needed

- [ ] Yes
- [x] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->



<!-- Add links to the documentation update PRs if/when they are created. -->



---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

none

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

no idea, please update this template if you have any insights

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

no idea, please update this template if you have any insights

#### What tests have been or will be added to CI for this change? If none, explain why.

no idea, please update this template if you have any insights

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
